### PR TITLE
Story/next version

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -37,8 +37,8 @@ ext.apply {
 
     // TODO remove these once we migrate publish.gradle to kts
 
-    set("LIB_VERSION_NAME", "1.4.3")
-    set("LIB_VERSION_CODE", 55)
+    set("LIB_VERSION_NAME", "1.4.4")
+    set("LIB_VERSION_CODE", 56)
 
     set("REPO", "fore")
     set("LIB_GROUP", "co.early.fore")

--- a/buildSrc/src/main/java/co/early/fore/Shared.kt
+++ b/buildSrc/src/main/java/co/early/fore/Shared.kt
@@ -45,6 +45,7 @@ object Shared {
         const val core_ktx = "1.3.2"
         const val kotlinx_coroutines_core = "1.4.2"
         const val kotlinx_coroutines_android = "1.4.2"
+        const val androidx_lifecycle_common = "2.2.0"
     }
 
     object BuildTypes {

--- a/buildSrc/src/main/java/co/early/fore/Shared.kt
+++ b/buildSrc/src/main/java/co/early/fore/Shared.kt
@@ -56,8 +56,8 @@ object Shared {
 
     object Publish {
         //LIB_VERSION_NAME="0.9.25-SNAPSHOT"
-        const val LIB_VERSION_NAME = "1.4.3"
-        const val LIB_VERSION_CODE = 55
+        const val LIB_VERSION_NAME = "1.4.4"
+        const val LIB_VERSION_CODE = 56
         const val REPO = "fore"
         const val LIB_GROUP = "co.early.fore"
         const val PROJ_NAME = "fore"
@@ -73,7 +73,7 @@ object Shared {
         const val LICENCE_NAME = "The Apache Software License, Version 2.0"
         const val LICENCE_URL = "http://www.apache.org/licenses/LICENSE-2.0.txt"
 
-        const val published_fore_version_for_examples = "1.4.3"
+        const val published_fore_version_for_examples = "1.4.4"
         const val use_published_version = false
     }
 }

--- a/docs/06-upgrading.md
+++ b/docs/06-upgrading.md
@@ -23,8 +23,11 @@ co.early.fore:fore-network-jv
 
 The java and kotlin packages will co-exist in the same app with no problem. To check what versions of what transitive dependencies each package pulls in, the definitive answer is found in the pom files hosted at [mavenCentral](https://repo1.maven.org/maven2/co/early/fore/). The other packages you will see in mavenCentral have been rolled in to the packages listed above and are no longer updated. The GPG fingerprint used to sign the maven packages is: <strong>5B83EC7248CCAEED24076AF87D1CC9121D51BA24</strong> and the GPG public cert is [here](https://erdo.github.io/android-fore/gpg-pub-cert.asc).
 
+## Gradle 6.1.1
+Gradle 6.1.1 (and Gradle Android build tools 4.0.0) is the minimum requirement from **fore 1.4.2** onwards due to the multi-version jar support
+
 ## kotlin 1.4.30
-From fore 1.4.1 onwards the version of kotlin was bumped up to **kotlin 1.4.30**
+From **fore 1.4.1** onwards the version of kotlin was bumped up to **kotlin 1.4.30**
 
 ## 1.4.0
 fore does not formally follow semantic versioning at the moment, the bump to 1.4.0 is simply because there have been some minor API changes to the adapters package in this release (all known sample apps and tutorials have been updated to reflect this already).

--- a/docs/06-upgrading.md
+++ b/docs/06-upgrading.md
@@ -3,7 +3,7 @@
 
 Since we've been publishing on <strike>jcenter</strike> & mavenCentral, the core code has remained almost identical. Most version number bumps have been due to updating dependencies, adding new classes to the optional packages, and occasionally tidying up the naming or the API (the version numbers for all the packages are incremented at the same time so that they will always match - this means some version bumps have no effect for a particular package).
 
-The fore library is divided into optional packages which you can pull in independently if you want (though the uber package is so small, it doesn't really seem worth it IMO).
+The fore library is divided into optional packages which you can pull in independently if you want (though the fat package is so small, it doesn't really seem worth it IMO).
 
 **kotlin** API
 ```
@@ -23,8 +23,8 @@ co.early.fore:fore-network-jv
 
 The java and kotlin packages will co-exist in the same app with no problem. To check what versions of what transitive dependencies each package pulls in, the definitive answer is found in the pom files hosted at [mavenCentral](https://repo1.maven.org/maven2/co/early/fore/). The other packages you will see in mavenCentral have been rolled in to the packages listed above and are no longer updated. The GPG fingerprint used to sign the maven packages is: <strong>5B83EC7248CCAEED24076AF87D1CC9121D51BA24</strong> and the GPG public cert is [here](https://erdo.github.io/android-fore/gpg-pub-cert.asc).
 
-## 1.4.1
-The version of kotlin has been bumped up to **kotlin 1.4.30**
+## kotlin 1.4.30
+From fore 1.4.1 onwards the version of kotlin was bumped up to **kotlin 1.4.30**
 
 ## 1.4.0
 fore does not formally follow semantic versioning at the moment, the bump to 1.4.0 is simply because there have been some minor API changes to the adapters package in this release (all known sample apps and tutorials have been updated to reflect this already).

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,7 +2,7 @@
 
 [![license-apache2](https://img.shields.io/badge/license-Apache%202-blue.svg)](https://github.com/erdo/android-fore/blob/master/LICENSE.txt){: .float-left}
 
-![central-1.4.3](https://img.shields.io/badge/central-1.4.3-green.svg){: .float-left}
+![central-1.4.4](https://img.shields.io/badge/central-1.4.4-green.svg){: .float-left}
 
 ![api-16](https://img.shields.io/badge/api-16%2B-orange.svg){: .float-left}
 
@@ -19,12 +19,12 @@
 
 the **kotlin** API, running coroutines under the hood:
 ```
-implementation "co.early.fore:fore-kt:1.4.3"
+implementation "co.early.fore:fore-kt:1.4.4"
 ```
 
 the original **java** API:
 ```
-implementation "co.early.fore:fore-jv:1.4.3"
+implementation "co.early.fore:fore-jv:1.4.4"
 ```
 
 *(and you now need mavenCentral() listed as a repository in your build files as jcenter is closing)*

--- a/fore-core-android-kt/build.gradle.kts
+++ b/fore-core-android-kt/build.gradle.kts
@@ -16,6 +16,7 @@ dependencies {
 
     api(project(":fore-core-kt"))
 
+    api("androidx.lifecycle:lifecycle-common-java8:${Shared.Versions.androidx_lifecycle_common}")
     //promote the kotlin-reflect version used in the android lint tools to match kotlin_version used elsewhere
     implementation("org.jetbrains.kotlin:kotlin-reflect:${Shared.Versions.kotlin_version}")
 

--- a/fore-core-android-kt/src/main/java/co/early/fore/kt/core/ui/ForeLifecycleObserver.kt
+++ b/fore-core-android-kt/src/main/java/co/early/fore/kt/core/ui/ForeLifecycleObserver.kt
@@ -1,0 +1,26 @@
+package co.early.fore.kt.core.ui
+
+import androidx.lifecycle.*
+import co.early.fore.core.observer.Observable
+import co.early.fore.core.observer.ObservableGroup
+import co.early.fore.core.observer.Observer
+import co.early.fore.core.ui.SyncableView
+import co.early.fore.kt.core.observer.ObservableGroupImp
+
+class ForeLifecycleObserver(
+    private val syncableView: SyncableView,
+    vararg observablesList: Observable
+) : DefaultLifecycleObserver {
+
+    private val observableGroup: ObservableGroup = ObservableGroupImp(*observablesList)
+    private val observer: Observer = Observer { syncableView.syncView() }
+
+    override fun onStart(owner: LifecycleOwner) {
+        observableGroup.addObserver(observer)
+        observer.somethingChanged()
+    }
+
+    override fun onStop(owner: LifecycleOwner) {
+        observableGroup.removeObserver(observer)
+    }
+}

--- a/fore-core-kt/build.gradle.kts
+++ b/fore-core-kt/build.gradle.kts
@@ -18,6 +18,7 @@ sourceSets["main"].java.apply {
     )
     exclude(
         "co/early/fore/core/logging/**",
+        "co/early/fore/core/observer/ObservableGroupImp.java",
         "co/early/fore/core/ui/SyncTrigger.java"
     )
 }

--- a/fore-core-kt/src/main/java/co/early/fore/kt/core/observer/ObservableGroupImp.kt
+++ b/fore-core-kt/src/main/java/co/early/fore/kt/core/observer/ObservableGroupImp.kt
@@ -1,0 +1,22 @@
+package co.early.fore.kt.core.observer
+
+import co.early.fore.core.observer.ObservableGroup
+import co.early.fore.core.observer.Observable
+import co.early.fore.core.observer.Observer
+
+class ObservableGroupImp(vararg observablesList: Observable) : ObservableGroup {
+
+    private val observablesList: List<Observable> = listOf(*observablesList)
+
+    override fun addObserver(observer: Observer) {
+        for (observable in observablesList) {
+            observable.addObserver(observer)
+        }
+    }
+
+    override fun removeObserver(observer: Observer) {
+        for (observable in observablesList) {
+            observable.removeObserver(observer)
+        }
+    }
+}


### PR DESCRIPTION
Adding a ForeLifecycleObserver as an option to reduce observer boiler plate on Activities and Fragments